### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Renaud Lainé", email = "renaud.laine@enea-consulting.com"},
 ]
 readme = "README.md"
-requires-python =  ">=3.10,<3.11"
+requires-python =  ">=3.10,<3.13"
 license = {text = "Copyright ENEA Australia Pty Ltd - All Rights Reserved. Proprietary and confidential"}
 dependencies = [
     "dash",


### PR DESCRIPTION
Is there any reason to force Python 3.10? Otherwise I would suggest to relax the Python constrain to allow newer, stable Python version (i.e. 3.11 and 3.12).