### PR TITLE
Skip json dump

### DIFF
--- a/dash_pydantic_form/utils.py
+++ b/dash_pydantic_form/utils.py
@@ -133,7 +133,7 @@ def get_model_value(item: BaseModel, field: str, parent: str, allow_default: boo
     try:
         subitem = get_subitem(item, parent)
         if isinstance(subitem, BaseModel):
-            return subitem.model_dump(mode="json")[field]
+            return subitem[field]
         if isinstance(subitem, dict) and isinstance(field, int):
             return list(subitem.values())[field]
         return subitem[field]


### PR DESCRIPTION
The json dump change the object from a `BaseModel` instance, which hinders e.g. custom rendering of accordion title. Here is a small example where the title is a json dump in the current code (with the json dump), while it renders correctly with the `callsign` as title when the json dump is remove (this PR),

```
from enum import Enum

import dash
import dash_mantine_components as dmc
from dash import Dash, Input, callback
from pydantic import BaseModel
from rich import print

from dash_pydantic_form.model_form import ModelForm


class PetType(Enum):
    DOG = "dog"
    CAT = "cat"


class Pet(BaseModel):
    callsign: str
    pet_type: PetType

    def __str__(self) -> str:
        return self.callsign


class PetClub(BaseModel):
    members: list[Pet]


dash._dash_renderer._set_react_version("18.2.0")  # type: ignore
app = Dash()
app.layout = dmc.MantineProvider(
    ModelForm(
        PetClub(
            members=[
                Pet(callsign="Thunder bark", pet_type=PetType.DOG),
                Pet(callsign="Lightning meow", pet_type=PetType.CAT),
            ]
        ),
        aio_id="pet_club",
        form_id="my_pet_club",
    )
)


@callback(Input(ModelForm.ids.main("pet_club", "my_pet_club"), "data"))
def on_form_change(data):
    print(data)


if __name__ == "__main__":
    app.run_server(debug=False, port=8888)
```

The example also includes an `Enum` field to demonstrate that the change does not cause issues with enums.