### PR TITLE
Feature/auto generated ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- possibility to omit ``aio_id`` and/or ``form_id`` in ``ModelForm``'s instanciation so they get auto-generated
 
 ## [0.10.1] - 2024-12-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- possibility to omit ``aio_id`` and/or ``form_id`` in ``ModelForm``'s instanciation so they get auto-generated
+- Possibility to omit ``aio_id`` and/or ``form_id`` in ``ModelForm``'s instanciation so they get auto-generated
+- Possibility to use the ModelForm instance ids in a callback
 
 ## [0.10.1] - 2024-12-16
 ### Fixed

--- a/dash_pydantic_form/model_form.py
+++ b/dash_pydantic_form/model_form.py
@@ -106,7 +106,7 @@ class IdAccess:
     @overload
     def __get__(self, obj: None, objtype=None) -> type[ModelFormIdsFactory]: ...
     def __get__(self, obj, objtype=None):
-        """Returns the ``ModelFormIdsFactory`` cass if accessed via the ``ModelForm`` class directly (ModelForm.ids)
+        """Returns the ``ModelFormIdsFactory`` class if accessed via the ``ModelForm`` class directly (ModelForm.ids)
         or an instance of ``ModelFormIds`` if accessed via an instance of ``ModelForm`` (ModelForm(my_model).ids).
         """
         if obj is None:
@@ -135,7 +135,7 @@ class ModelForm(html.Div):
         with existing values.
     aio_id: str | None
         All-in-one component ID. A pseudo-random string will be auto-generated if not provided.
-    form_id: str
+    form_id: str | None
         Form ID, can be used to create multiple forms on the same page. When working with databases
         this could be the document / record ID. A pseudo-random string will be auto-generated if not provided.
     form_cols: int

--- a/dash_pydantic_form/model_form.py
+++ b/dash_pydantic_form/model_form.py
@@ -1,9 +1,11 @@
 import contextlib
+import dataclasses as dc
 import itertools
+import uuid
 import warnings
 from copy import deepcopy
 from functools import partial
-from typing import Annotated, Literal, Union, get_args, get_origin
+from typing import Annotated, Literal, Union, get_args, get_origin, overload
 
 import dash_mantine_components as dmc
 from dash import (
@@ -19,7 +21,7 @@ from dash import (
     dcc,
     html,
 )
-from dash.development.base_component import Component
+from dash.development.base_component import Component, rd
 from dash_iconify import DashIconify
 from pydantic import BaseModel
 
@@ -51,6 +53,77 @@ SectionRender = Literal["accordion", "tabs", "steps"]
 Position = Literal["top", "bottom", "none"]
 
 
+class ModelFormIdsFactory:
+    """Factory functions for model form ids."""
+
+    form = partial(form_base_id, "_pydf-form")
+    main = partial(form_base_id, "_pydf-main")
+    errors = partial(form_base_id, "_pydf-errors")
+    accordion = partial(form_base_id, "_pydf-accordion")
+    tabs = partial(form_base_id, "_pydf-tabs")
+    steps = partial(form_base_id, "_pydf-steps")
+    steps_save = partial(form_base_id, "_pydf-steps-save")
+    steps_next = partial(form_base_id, "_pydf-steps-next")
+    steps_previous = partial(form_base_id, "_pydf-steps-previous")
+    steps_nsteps = partial(form_base_id, "_pydf-steps-nsteps")
+    model_store = partial(form_base_id, "_pydf-model-store")
+    form_specs_store = partial(form_base_id, "_pydf-form-specs-store")
+
+
+@dc.dataclass(frozen=True)
+class ModelFormIds:
+    """Model form ids."""
+
+    form: dict[str, str]
+    main: dict[str, str]
+    errors: dict[str, str]
+    accordion: dict[str, str]
+    tabs: dict[str, str]
+    steps: dict[str, str]
+    steps_save: dict[str, str]
+    steps_next: dict[str, str]
+    steps_previous: dict[str, str]
+    steps_nsteps: dict[str, str]
+    model_store: dict[str, str]
+    form_specs_store: dict[str, str]
+
+    @classmethod
+    def from_basic_ids(cls, aio_id: str, form_id: str) -> "ModelFormIds":
+        """Instanciation from aio_id and form_id."""
+        return cls(
+            *(
+                getattr(ModelFormIdsFactory, id_field.name)(aio_id, form_id)
+                for id_field in dc.fields(cls)
+            )
+        )
+
+
+class IdAccess:
+    """Descriptor for handling access to either instances or the factory of model form ids via ``ModelForm`` class."""
+
+    @overload
+    def __get__(self, obj: "ModelForm", objtype=None) -> ModelFormIds: ...
+    @overload
+    def __get__(self, obj: None, objtype=None) -> type[ModelFormIdsFactory]: ...
+    def __get__(self, obj, objtype=None):
+        """Returns the ``ModelFormIdsFactory`` cass if accessed via the ``ModelForm`` class directly (ModelForm.ids)
+        or an instance of ``ModelFormIds`` if accessed via an instance of ``ModelForm`` (ModelForm(my_model).ids).
+        """
+        if obj is None:
+            # access via class
+            return ModelFormIdsFactory
+
+        # access via instance
+        return obj._ids
+
+    def __set__(self, obj: "ModelForm", value: ModelFormIds | tuple[str, str]):
+        """Sets another set of model form ids to a ``ModelForm`` object."""
+        if isinstance(value, tuple):
+            value = ModelFormIds.from_basic_ids(*value)
+
+        obj._ids = value
+
+
 class ModelForm(html.Div):
     """Create a Dash form from a pydantic model.
 
@@ -60,11 +133,11 @@ class ModelForm(html.Div):
         The model to create the form from, can be the model class or an instance of the class.
         If the class is passed, the form will be empty. If an instance is passed, the form will be pre-filled
         with existing values.
-    aio_id: str
-        All-in-one component ID
+    aio_id: str | None
+        All-in-one component ID. A pseudo-random string will be auto-generated if not provided.
     form_id: str
         Form ID, can be used to create multiple forms on the same page. When working with databases
-        this could be the document / record ID.
+        this could be the document / record ID. A pseudo-random string will be auto-generated if not provided.
     form_cols: int
         Number of columns in the form, defaults to 4.
     fields_repr: dict[str, dict | BaseField] | None
@@ -92,27 +165,13 @@ class ModelForm(html.Div):
         Deprecated, use `form_cols` instead.
     """
 
-    class ids:
-        """Model form ids."""
-
-        form = partial(form_base_id, "_pydf-form")
-        main = partial(form_base_id, "_pydf-main")
-        errors = partial(form_base_id, "_pydf-errors")
-        accordion = partial(form_base_id, "_pydf-accordion")
-        tabs = partial(form_base_id, "_pydf-tabs")
-        steps = partial(form_base_id, "_pydf-steps")
-        steps_save = partial(form_base_id, "_pydf-steps-save")
-        steps_next = partial(form_base_id, "_pydf-steps-next")
-        steps_previous = partial(form_base_id, "_pydf-steps-previous")
-        steps_nsteps = partial(form_base_id, "_pydf-steps-nsteps")
-        model_store = partial(form_base_id, "_pydf-model-store")
-        form_specs_store = partial(form_base_id, "_pydf-form-specs-store")
+    ids = IdAccess()
 
     def __init__(  # noqa: PLR0912, PLR0913, PLR0915
         self,
         item: BaseModel | type[BaseModel],
-        aio_id: str,
-        form_id: str,
+        aio_id: str | None = None,
+        form_id: str | None = None,
         path: str = "",
         form_cols: int = 4,
         fields_repr: dict[str, Union["BaseField", dict]] | None = None,
@@ -129,6 +188,10 @@ class ModelForm(html.Div):
         with contextlib.suppress(Exception):
             if issubclass(item, BaseModel):
                 item = item.model_construct()
+
+        aio_id = aio_id or str(uuid.UUID(int=rd.randint(0, 2**128)))
+        form_id = form_id or str(uuid.UUID(int=rd.randint(0, 2**128)))
+        self._ids = ModelFormIds.from_basic_ids(aio_id, form_id)
 
         if cols is not None:
             warnings.warn("cols is deprecated, use form_cols instead", DeprecationWarning, stacklevel=1)
@@ -184,7 +247,7 @@ class ModelForm(html.Div):
             style=style,
             **(
                 {
-                    "id": self.ids.form(aio_id, form_id, path),
+                    "id": ModelFormIdsFactory.form(aio_id, form_id, path),
                     "data-submitonenter": submit_on_enter,
                 }
                 if not path

--- a/tests/test_auto_generated_ids.py
+++ b/tests/test_auto_generated_ids.py
@@ -1,0 +1,138 @@
+import json
+from datetime import date
+from enum import Enum
+from typing import Literal
+
+import dash_mantine_components as dmc
+import pytest
+from dash import Dash, Input, Output
+from pydantic import BaseModel, Field
+
+from dash_pydantic_form import ModelForm, ids
+from dash_pydantic_form.model_form import rd
+from tests.utils import (
+    check_elem_values,
+    check_ids_exist,
+    get_field_ids,
+    set_checkbox,
+    set_input,
+    set_select,
+)
+
+
+class E(Enum):
+    """Test enum."""
+
+    A = "A"
+    B = "B"
+
+
+class Basic(BaseModel):
+    """Basic model."""
+
+    a: int = Field(title="Field A")
+    b: str = Field(title="Field A")
+    c: Literal["a", "b"] = Field(title="Field C")
+    d: bool = Field(title="Field D")
+    e: E = Field(title="Field E")
+    f: date = Field(title="Field F")
+
+
+basic_data = {"a": 1, "b": "foo", "c": "a", "d": True, "e": "B", "f": "2022-01-01"}
+
+
+@pytest.fixture(autouse=True)
+def reset_random_numbers():
+    """Resets the seed so each test works as single test or in a bunch."""
+    rd.seed(0)
+
+
+def test_agi0001_auto_generation():
+    """Test a basic form."""
+    # expected values for aio_id and form_id as they are pseudo-generated but deterministic as long as
+    # the "program flow" keeps the same
+    aio_id = "e3e70682-c209-4cac-629f-6fbed82c07cd"
+    form_id = "82e2e662-f728-b4fa-4248-5e3a0a5d2f34"
+
+    form = ModelForm(Basic)
+    assert form.id == form.ids.form  # type: ignore
+    assert form.ids.form == {
+        'part': '_pydf-form',
+        'aio_id': aio_id,
+        'form_id': form_id,
+        'parent': ''
+    }
+    assert form.ids.main == {
+        'part': '_pydf-main',
+        'aio_id': aio_id,
+        'form_id': form_id,
+        'parent': ''
+    }
+    assert form.ids.errors == {
+        'part': '_pydf-errors',
+        'aio_id': aio_id,
+        'form_id': form_id,
+        'parent': ''
+    }
+
+    check_ids_exist(form, list(get_field_ids(Basic, aio_id, form_id)))
+    check_elem_values(
+        form,
+        {
+            json.dumps(fid): None if fid["component"] == ids.value_field.args[0] else False
+            for fid in get_field_ids(Basic, aio_id, form_id)
+        },
+    )
+
+    assert list(basic_data) == list(Basic.model_fields)
+    # expected pseudo-random ids
+    aio_id = "d4713d60-c8a7-0639-eb11-67b367a9c378"
+    form_id = "23a7711a-8133-2876-37eb-dcd9e87a1613"
+
+    item = Basic(**basic_data)
+    form_filled = ModelForm(item)
+    assert form_filled.ids.form["aio_id"] == aio_id
+    assert form_filled.ids.form["form_id"] == form_id
+    check_ids_exist(form_filled, list(get_field_ids(Basic, aio_id, form_id)))
+    check_elem_values(
+        form_filled,
+        {
+            json.dumps(fid): val
+            for fid, val in zip(get_field_ids(Basic, aio_id, form_id), item.model_dump().values(), strict=True)
+        },
+    )
+
+
+def test_agi0002_usage_in_browser_and_callback(dash_duo):
+    """Test a basic form, retrieving its form data."""
+    app = Dash(__name__)
+    item = Basic(**basic_data)
+    # expected pseudo-random ids
+    aio_id = "e3e70682-c209-4cac-629f-6fbed82c07cd"
+    form_id = "82e2e662-f728-b4fa-4248-5e3a0a5d2f34"
+
+    app.layout = dmc.MantineProvider(
+        [
+            form:=ModelForm(item),
+            dmc.Text(id="output"),
+        ]
+    )
+
+    @app.callback(
+        Output("output", "children"),
+        Input(form.ids.main, "data"),
+    )
+    def display(form_data):
+        return json.dumps(form_data, sort_keys=True)
+
+    dash_duo.start_server(app)
+
+    set_input(dash_duo, ids.value_field(aio_id, form_id, "a"), basic_data["a"])
+    dash_duo.wait_for_text_to_equal("#output", json.dumps(basic_data, sort_keys=True))
+
+    set_input(dash_duo, ids.value_field(aio_id, form_id, "a"), 123)
+    set_select(dash_duo, ids.value_field(aio_id, form_id, "c"), "b")
+    set_checkbox(dash_duo, ids.checked_field(aio_id, form_id, "d"), False)
+    dash_duo.wait_for_text_to_equal(
+        "#output", json.dumps(basic_data | {"a": 123, "c": "b", "d": False}, sort_keys=True)
+    )

--- a/tests/test_auto_generated_ids.py
+++ b/tests/test_auto_generated_ids.py
@@ -56,24 +56,9 @@ def test_agi0001_auto_generation():
 
     form = ModelForm(Basic)
     assert form.id == form.ids.form  # type: ignore
-    assert form.ids.form == {
-        'part': '_pydf-form',
-        'aio_id': aio_id,
-        'form_id': form_id,
-        'parent': ''
-    }
-    assert form.ids.main == {
-        'part': '_pydf-main',
-        'aio_id': aio_id,
-        'form_id': form_id,
-        'parent': ''
-    }
-    assert form.ids.errors == {
-        'part': '_pydf-errors',
-        'aio_id': aio_id,
-        'form_id': form_id,
-        'parent': ''
-    }
+    assert form.ids.form == {"part": "_pydf-form", "aio_id": aio_id, "form_id": form_id, "parent": ""}
+    assert form.ids.main == {"part": "_pydf-main", "aio_id": aio_id, "form_id": form_id, "parent": ""}
+    assert form.ids.errors == {"part": "_pydf-errors", "aio_id": aio_id, "form_id": form_id, "parent": ""}
 
     check_ids_exist(form, list(get_field_ids(Basic, aio_id, form_id)))
     check_elem_values(
@@ -113,7 +98,7 @@ def test_agi0002_usage_in_browser_and_callback(dash_duo):
 
     app.layout = dmc.MantineProvider(
         [
-            form:=ModelForm(item),
+            form := ModelForm(item),
             dmc.Text(id="output"),
         ]
     )


### PR DESCRIPTION
Closes #41 

Add possibility to omit ``aio_id`` and/or ``form_id`` in ``ModelForm``'s instanciation so they get auto-generated.

**Note**:
- Since callbacks need to be defined in advance, you can’t use this if you are defining chunks of layouts with a callback that updates a ``children`` property. For example, if you create and return a ``ModelForm`` component inside a callback, you must provide an ID to that model form. Otherwise, you will not be able to use that model form in other callbacks.  
Probably this should be documented somewhere? [The same constraint holds for dash's id-auto-generation feature](https://community.plotly.com/t/dash-2-1-0-released/60548).
- This will most probably not work with [persistence](https://dash.plotly.com/persistence) or [Dash Enterprise Snapshot or Report Engine](https://plotly.com/dash/snapshot-engine/) (which is also a constraint for dash's id-auto-generation).
- Contrary to dash's id-auto-generation mechanism, the ids here are already auto-generated when instanciating a ``ModelForm`` object and are saved in the ``_ids`` attribute (can that be a problem in some case?). But the concept of creating pseudo-random ids which are deterministic (keep being the same for each execution) as long as the code does not change is the same here.