### PR TITLE
Add download button to Table field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `with_download` parameter in Table field
 
 ## [0.14.0] - 2025-01-28
 ### Changed

--- a/packages/dash-pydantic-form/dash_pydantic_form/fields/table_field.py
+++ b/packages/dash-pydantic-form/dash_pydantic_form/fields/table_field.py
@@ -548,3 +548,9 @@ class TableField(BaseField):
             data_df = pd.DataFrame(table_data)
             return dcc.send_data_frame(data_df.to_csv, "table_data.csv", index=False, encoding="utf-8")
         return no_update
+
+    clientside_callback(
+        """ data => !(Array.isArray(data) && data.length) """,
+        Output(ids.download_csv_btn(MATCH, MATCH, MATCH, parent=MATCH), "disabled"),
+        Input(ids.editable_table(MATCH, MATCH, MATCH, parent=MATCH), "rowData"),
+    )

--- a/packages/dash-pydantic-form/dash_pydantic_form/fields/table_field.py
+++ b/packages/dash-pydantic-form/dash_pydantic_form/fields/table_field.py
@@ -89,6 +89,8 @@ class TableField(BaseField):
 
         editable_table = partial(field_dependent_id, "_pydf-editable-table-table")
         upload_csv = partial(field_dependent_id, "_pydf-editable-table-upload")
+        download_csv = partial(field_dependent_id, "_pydf-editable-table-download")
+        download_csv_btn = partial(field_dependent_id, "_pydf-editable-table-download_btn")
         add_row = partial(field_dependent_id, "_pydf-editable-table-add-row")
         notification_wrapper = partial(field_dependent_id, "_pydf-editable-table-notification-wrapper")
 
@@ -205,6 +207,12 @@ class TableField(BaseField):
                     position="top-start",
                     styles={"dropdown": {"maxWidth": "min(90vw, 500px)"}},
                 ),
+                dmc.Button(
+                    _("Download CSV"),
+                    id=self.ids.download_csv_btn(aio_id, form_id, field, parent=parent),
+                    size="compact-sm",
+                ),
+                dcc.Download(id=self.ids.download_csv(aio_id, form_id, field, parent=parent)),
             ]
 
         add_row = []
@@ -506,4 +514,19 @@ class TableField(BaseField):
         """Add new row in editable table on user click."""
         if n_clicks is not None:
             return {"add": [{col["field"]: col.get("default_value") for col in column_defs if "field" in col}]}
+        return no_update
+
+    @callback(
+        Output(ids.download_csv(MATCH, MATCH, MATCH, parent=MATCH), "data"),
+        Input(ids.download_csv_btn(MATCH, MATCH, MATCH, parent=MATCH), "n_clicks"),
+        State(ids.editable_table(MATCH, MATCH, MATCH, parent=MATCH), "rowData"),
+        prevent_initial_call=True,
+    )
+    def table_to_csv(n_clicks, table_data):
+        """Send the table data to the user as a CSV file."""
+        if n_clicks:
+            import pandas as pd
+
+            data_df = pd.DataFrame(table_data)
+            return dcc.send_data_frame(data_df.to_csv, "table_data.csv", index=False, encoding="utf-8-sig")
         return no_update

--- a/packages/dash-pydantic-form/dash_pydantic_form/fields/table_field.py
+++ b/packages/dash-pydantic-form/dash_pydantic_form/fields/table_field.py
@@ -90,7 +90,7 @@ class TableField(BaseField):
         editable_table = partial(field_dependent_id, "_pydf-editable-table-table")
         upload_csv = partial(field_dependent_id, "_pydf-editable-table-upload")
         download_csv = partial(field_dependent_id, "_pydf-editable-table-download")
-        download_csv_btn = partial(field_dependent_id, "_pydf-editable-table-download_btn")
+        download_csv_btn = partial(field_dependent_id, "_pydf-editable-table-download-btn")
         add_row = partial(field_dependent_id, "_pydf-editable-table-add-row")
         notification_wrapper = partial(field_dependent_id, "_pydf-editable-table-notification-wrapper")
 

--- a/packages/dash-pydantic-form/dash_pydantic_form/locales/en/LC_MESSAGES/pydf.po
+++ b/packages/dash-pydantic-form/dash_pydantic_form/locales/en/LC_MESSAGES/pydf.po
@@ -69,6 +69,9 @@ msgstr "OPTIONAL"
 msgid "Upload CSV"
 msgstr "Upload CSV"
 
+msgid "Download CSV"
+msgstr "Download CSV"
+
 msgid "Add row"
 msgstr "Add row"
 

--- a/packages/dash-pydantic-form/dash_pydantic_form/locales/fr/LC_MESSAGES/pydf.po
+++ b/packages/dash-pydantic-form/dash_pydantic_form/locales/fr/LC_MESSAGES/pydf.po
@@ -72,6 +72,9 @@ msgstr "OPTIONNELLES"
 msgid "Upload CSV"
 msgstr "Ajouter via CSV"
 
+msgid "Download CSV"
+msgstr "Télécharger le CSV"
+
 msgid "Add row"
 msgstr "Ajouter une ligne"
 

--- a/packages/dash-pydantic-form/dash_pydantic_form/locales/pydf.pot
+++ b/packages/dash-pydantic-form/dash_pydantic_form/locales/pydf.pot
@@ -82,39 +82,43 @@ msgstr ""
 msgid "No match"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:116
+#: dash_pydantic_form/fields/table_field.py:124
 msgid "Drag & drop a csv file or "
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:117
+#: dash_pydantic_form/fields/table_field.py:125
 msgid "select it"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:122
+#: dash_pydantic_form/fields/table_field.py:130
 msgid "CSV columns"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:125
+#: dash_pydantic_form/fields/table_field.py:133
 msgid "REQUIRED"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:152
+#: dash_pydantic_form/fields/table_field.py:160
 msgid "OPTIONAL"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:195
+#: dash_pydantic_form/fields/table_field.py:203
 msgid "Upload CSV"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:208
+#: dash_pydantic_form/fields/table_field.py:211
+msgid "Download CSV"
+msgstr ""
+
+#: dash_pydantic_form/fields/table_field.py:222
 msgid "Add row"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:474
+#: dash_pydantic_form/fields/table_field.py:499
 msgid "Wrong column names"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:475
+#: dash_pydantic_form/fields/table_field.py:500
 msgid "CSV upload failed, the file should contain the following columns: "
 msgstr ""
 

--- a/packages/dash-pydantic-form/dash_pydantic_form/locales/pydf.pot
+++ b/packages/dash-pydantic-form/dash_pydantic_form/locales/pydf.pot
@@ -82,43 +82,43 @@ msgstr ""
 msgid "No match"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:124
+#: dash_pydantic_form/fields/table_field.py:132
 msgid "Drag & drop a csv file or "
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:125
+#: dash_pydantic_form/fields/table_field.py:133
 msgid "select it"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:130
+#: dash_pydantic_form/fields/table_field.py:138
 msgid "CSV columns"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:133
+#: dash_pydantic_form/fields/table_field.py:141
 msgid "REQUIRED"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:160
+#: dash_pydantic_form/fields/table_field.py:168
 msgid "OPTIONAL"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:203
+#: dash_pydantic_form/fields/table_field.py:211
 msgid "Upload CSV"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:211
+#: dash_pydantic_form/fields/table_field.py:224
 msgid "Download CSV"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:222
+#: dash_pydantic_form/fields/table_field.py:235
 msgid "Add row"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:499
+#: dash_pydantic_form/fields/table_field.py:516
 msgid "Wrong column names"
 msgstr ""
 
-#: dash_pydantic_form/fields/table_field.py:500
+#: dash_pydantic_form/fields/table_field.py:517
 msgid "CSV upload failed, the file should contain the following columns: "
 msgstr ""
 


### PR DESCRIPTION
Hey Renaud!

It's often useful to be able to download the table, for example to have the template if we want to change the data and reupload the CSV.

So I added a download button next to the upload one to allow that

Not sure how the whole translation thing works, I added what seemed relevant

![image](https://github.com/user-attachments/assets/ad6f2407-ddc1-4490-9889-c0245a70d3df)
