### PR TITLE
Adjustment for Index for the Accordion in Lists

### DIFF
--- a/packages/dash-pydantic-form/dash_pydantic_form/fields/list_field.py
+++ b/packages/dash-pydantic-form/dash_pydantic_form/fields/list_field.py
@@ -270,10 +270,7 @@ class ListField(BaseField):
             items.append(list_item)
             if passed_opened_value is not None:
                 if wrapper_kwargs.get("multiple", False):
-                    if isinstance(passed_opened_value, list):
-                        if i in passed_opened_value:
-                            opened_value.append(value_uid)
-                    elif passed_opened_value == i:
+                    if (isinstance(passed_opened_value, list) and i in passed_opened_value) or passed_opened_value == i:
                         opened_value.append(value_uid)
                 elif passed_opened_value == i:
                     opened_value = value_uid

--- a/tests/test_basic_form.py
+++ b/tests/test_basic_form.py
@@ -226,7 +226,8 @@ def test_bf0006_store_progress_notify(dash_duo):
         fid = ids.value_field(aio_id, form_id, field)
         str_id = stringify_id(fid)
         until(
-            lambda: dash_duo.driver.find_element(By.ID, str_id).get_property("value") == str(basic_data[field]),
+            lambda str_id=str_id, field=field: dash_duo.driver.find_element(By.ID, str_id).get_property("value")
+            == str(basic_data[field]),
             timeout=3,
         )
 
@@ -240,7 +241,8 @@ def test_bf0006_store_progress_notify(dash_duo):
         fid = ids.value_field(aio_id, form_id, field)
         str_id = stringify_id(fid)
         until(
-            lambda: dash_duo.driver.find_element(By.ID, str_id).get_property("value") == str(basic_data[field]),
+            lambda str_id=str_id, field=field: dash_duo.driver.find_element(By.ID, str_id).get_property("value")
+            == str(basic_data[field]),
             timeout=3,
         )
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,6 +1,5 @@
 import json
 from datetime import date, time
-from typing import Optional
 
 import dash_mantine_components as dmc
 from dash import Dash, Input, Output
@@ -152,7 +151,7 @@ def test_li0004_model_list_first_opened(dash_duo):
         )
 
     class Basic(BaseModel):
-        a: list[Nested] = Field(repr_kwargs=dict(wrapper_kwargs={"initially_opened_value": 0}))
+        a: list[Nested] = Field(repr_kwargs={"wrapper_kwargs": {"initially_opened_value": 0}})
 
     app = Dash(__name__)
     item = Basic(**{"a": [{"name": "Item 1"}, {"name": "Item 2"}]})
@@ -183,6 +182,7 @@ def test_li0004_model_list_first_opened(dash_duo):
     assert input0.is_displayed()
     assert not input1.is_displayed()
 
+
 def test_li0005_model_list_first_opened(dash_duo):
     """Test a model list with initially opened items."""
 
@@ -194,8 +194,7 @@ def test_li0005_model_list_first_opened(dash_duo):
         )
 
     class Basic(BaseModel):
-        a: list[Nested] = Field(repr_kwargs=dict(wrapper_kwargs={"initially_opened_value": [0,2],
-                                                                 'multiple': True}))
+        a: list[Nested] = Field(repr_kwargs={"wrapper_kwargs": {"initially_opened_value": [0, 2], "multiple": True}})
 
     app = Dash(__name__)
     item = Basic(**{"a": [{"name": "Item 1"}, {"name": "Item 2"}, {"name": "Item 3"}]})


### PR DESCRIPTION
adjustments to allow for devs to pass an opened list (index) to the list `wrapper_kwargs` to have a list item already opened