### PR TITLE
adjusting `sortedJson` to use `dash_component_api.stringifyId` if available

### DIFF
--- a/packages/dash-pydantic-form/dash_pydantic_form/pydf_clientside.js
+++ b/packages/dash-pydantic-form/dash_pydantic_form/pydf_clientside.js
@@ -222,7 +222,7 @@ dash_clientside.pydf = {
         }
         const firstValueField = findFirstValueField(templateCopy);
         if (firstValueField) {
-            waitForElem(sortedJson(firstValueField)).then((el) => {
+            waitForElem(stringifyId(firstValueField)).then((el) => {
                 el.focus();
             });
         }
@@ -433,13 +433,20 @@ function waitForElem(id) {
 }
 
 const sortedJson = (obj) => {
-    if (window.dash_component_api && window.dash_component_api.stringifyId) {
-        return window.dash_component_api.stringifyId(obj);
-    }
     const allKeys = new Set();
     JSON.stringify(obj, (key, value) => (allKeys.add(key), value));
     return JSON.stringify(obj, Array.from(allKeys).sort());
 };
+
+const stringifyId = (id) => {
+    if (window.dash_component_api && window.dash_component_api.stringifyId) {
+        return window.dash_component_api.stringifyId(id);
+    }
+    if (typeof id === "object") {
+        return sortedJson(id);
+    }
+    return id;
+}
 
 // Return a : separated string of the args
 const getFullpath = (...args) => {


### PR DESCRIPTION
In the event that Dash ever changes the way they handle the parsing of the objects, this will update automatically.

This is available since Dash 3.