### PR TITLE
fix: Excel CSV's fail

### DIFF
--- a/packages/dash-pydantic-form/dash_pydantic_form/fields/table_field.py
+++ b/packages/dash-pydantic-form/dash_pydantic_form/fields/table_field.py
@@ -579,7 +579,6 @@ def csv_to_table(contents: str, column_defs: list[dict]):
 
         # Error notification for missing required columns
         if missing_required_columns := list(set(required_columns) - set(data_columns)):
-            
             required_column_items = [
                 dmc.ListItem(
                     dmc.Text(

--- a/tests/test_table_field.py
+++ b/tests/test_table_field.py
@@ -23,9 +23,10 @@ def test_csv_to_table_success():
     ]
     assert notification is None
 
+
 def test_csv_to_table_success_BOM():
     """Test successful CSV parsing into row data when it has a Byte Order Mark (BOM)."""
-    csv_content = "\ufeffcol1,col2\nval1,1\nval2,2" # \ufeff is microsoft BOM, checking it reads fine
+    csv_content = "\ufeffcol1,col2\nval1,1\nval2,2"  # \ufeff is microsoft BOM, checking it reads fine
     contents = "data:text/csv;base64," + base64.b64encode(csv_content.encode()).decode()
     column_defs = [
         {"field": "col1", "dtype": "str"},


### PR DESCRIPTION
- Use "utf-8-sig" instead of "utf-8"
- Only list columns which failed in error